### PR TITLE
Creating a patient bill alert for patients with pending bills

### DIFF
--- a/src/billable-commodities/billable-commodities.component.tsx
+++ b/src/billable-commodities/billable-commodities.component.tsx
@@ -22,7 +22,7 @@ import {
 import { ArrowRight } from '@carbon/react/icons';
 import { useLayoutType, isDesktop, usePagination, ErrorState, showModal } from '@openmrs/esm-framework';
 import { EmptyState } from '@openmrs/esm-patient-common-lib';
-import { useBillableCommodities, useBillableServices } from '../billable-services/billable-service.resource';
+import { useBillableCommodities } from '../billable-services/billable-service.resource';
 import styles from '../billable-services/billable-services.scss';
 import AddBillableStock from './add-billable-commodity.component';
 import classNames from 'classnames';
@@ -51,7 +51,7 @@ const BillableStock = () => {
   ];
 
   const launchBillableCommoditiesForm = useCallback(() => {
-    const dispose = showModal('charge-item-modal', {
+    const dispose = showModal('require-billing-modal', {
       editingItem: null,
       onClose: () => dispose(),
     });

--- a/src/billing.resource.ts
+++ b/src/billing.resource.ts
@@ -1,8 +1,8 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 import dayjs from 'dayjs';
 import isEmpty from 'lodash-es/isEmpty';
 import sortBy from 'lodash-es/sortBy';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import {
   formatDate,
   parseDate,
@@ -235,5 +235,21 @@ export function useFacilityName() {
     facility: data?.data?.value ?? '',
     isLoadingFacility: isLoading,
     isError: error,
+  };
+}
+
+export function usePatientBills(patientUuid: string) {
+  const apiUrl = patientUuid ? `${apiBasePath}bill?patientUuid=${patientUuid}&v=full` : null;
+
+  const { data, isLoading, error } = useSWR<{ data: { results: Array<PatientInvoice> } }, Error>(apiUrl, openmrsFetch);
+
+  const patientBills = useMemo(() => {
+    return data?.data?.results ?? [];
+  }, [data?.data?.results]);
+  return {
+    patientBills: patientBills ?? [],
+    isLoading,
+    error,
+    mutate,
   };
 }

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -68,6 +68,12 @@ export const configSchema = {
     _description: 'Whether to show the edit bill button or not.',
     _default: false,
   },
+
+  enforceBillPayment: {
+    _type: Type.Boolean,
+    _description: 'Whether to enfore bill payment before providing care to a patient or not.',
+    _default: false,
+  },
 };
 
 export interface ConfigObject {
@@ -80,4 +86,5 @@ export interface ConfigObject {
   postBilledItems: Object;
   serviceTypes: string;
   nonPayingPatientCategories: Object;
+  enforceBillPayment: boolean;
 }

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -62,3 +62,20 @@ export const getGender = (gender: string, t) => {
       return gender;
   }
 };
+
+/**
+ * Extracts and returns the substring after the first colon (:) in the input string.
+ * If there's no colon or the input is invalid, returns the original string.
+ * The input string is typically in the format "uuid:string".
+ *
+ * @param {string} input - The input string from which the substring is to be extracted.
+ * @returns {string} The substring found after the first colon, or the original string if no colon is present.
+ */
+export function extractString(input: string): string {
+  if (!input || typeof input !== 'string') {
+    return '';
+  }
+
+  const parts = input.split(':');
+  return parts.length > 1 ? parts[1] : input;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import BillableServiceHome from './billable-services/billable-services-home.comp
 import BillableServicesCardLink from './billable-services-admin-card-link.component';
 import BillHistory from './bill-history/bill-history.component';
 import BillingCheckInForm from './billing-form/billing-checkin-form.component';
-import RequirePaymentModal from './modal/require-payment-modal.component';
+import RequirePaymentModal from './prompt-payment/prompt-payment.component';
 import RootComponent from './root.component';
 import ServiceMetrics from './billable-services/dashboard/service-metrics.component';
 import VisitAttributeTags from './invoice/payments/visit-tags/visit-attribute.component';

--- a/src/prompt-payment/prompt-payment.component.tsx
+++ b/src/prompt-payment/prompt-payment.component.tsx
@@ -41,6 +41,10 @@ const PromptPaymentModal: React.FC = () => {
     .flatMap((bill) => bill.lineItems)
     .filter((lineItem) => lineItem.paymentStatus !== 'PAID');
 
+  if (lineItems.length === 0) {
+    return null;
+  }
+
   return (
     <ComposedModal preventCloseOnClickOutside open={showModal.billingModal}>
       {isLoading ? (

--- a/src/prompt-payment/prompt-payment.component.tsx
+++ b/src/prompt-payment/prompt-payment.component.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Button,
+  ComposedModal,
+  Heading,
+  ModalBody,
+  ModalFooter,
+  StructuredListBody,
+  StructuredListCell,
+  StructuredListHead,
+  StructuredListRow,
+  StructuredListWrapper,
+  InlineLoading,
+} from '@carbon/react';
+import styles from './prompt-payment.scss';
+import { navigate, useConfig, usePatient } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../config-schema';
+import { usePatientBills } from '../billing.resource';
+import { convertToCurrency, extractString } from '../helpers';
+
+const PromptPaymentModal: React.FC = () => {
+  const { t } = useTranslation();
+  const { patientUuid } = usePatient();
+  const { patientBills: bills, isLoading, error, mutate } = usePatientBills(patientUuid ?? '');
+  const [showModal, setShowModal] = useState({ billingModal: true });
+  const { enforceBillPayment, defaultCurrency } = useConfig<ConfigObject>();
+
+  const closeButtonText = enforceBillPayment
+    ? t('naviagetBack', 'Navigate back')
+    : t('proceedToCare', 'Proceed to care');
+
+  const handleCloseModal = () => {
+    enforceBillPayment
+      ? navigate({ to: `\${openmrsSpaBase}/home` })
+      : setShowModal((prevState) => ({ ...prevState, billingModal: false }));
+  };
+
+  const lineItems = bills
+    .filter((bill) => bill.status !== 'PAID')
+    .flatMap((bill) => bill.lineItems)
+    .filter((lineItem) => lineItem.paymentStatus !== 'PAID');
+
+  return (
+    <ComposedModal preventCloseOnClickOutside open={showModal.billingModal}>
+      {isLoading ? (
+        <ModalBody>
+          <Heading className={styles.modalTitle}>{t('billingStatus', 'Billing status')}</Heading>
+          <InlineLoading
+            status="active"
+            iconDescription="Loading"
+            description={t('verifyingPatientBills', 'Verifying patient bills')}
+          />
+        </ModalBody>
+      ) : (
+        <ModalBody>
+          <Heading className={styles.modalTitle}>{t('patientBillingAlert', 'Patient Billing Alert')}</Heading>
+          <p className={styles.bodyShort02}>
+            {t('billSettlementMessage', 'The current patient has pending bill. Advise patient to settle bill.')}
+          </p>
+          <StructuredListWrapper isCondensed>
+            <StructuredListHead>
+              <StructuredListRow head>
+                <StructuredListCell head>{t('item', 'Item')}</StructuredListCell>
+                <StructuredListCell head>{t('quantity', 'Quantity')}</StructuredListCell>
+                <StructuredListCell head>{t('unitPrice', 'Unit Price')}</StructuredListCell>
+                <StructuredListCell head>{t('paymentstatus', 'Payment status')}</StructuredListCell>
+                <StructuredListCell head>{t('total', 'Total')}</StructuredListCell>
+              </StructuredListRow>
+            </StructuredListHead>
+            <StructuredListBody>
+              {lineItems.map((lineItem) => {
+                return (
+                  <StructuredListRow key={lineItem.uuid}>
+                    <StructuredListCell>{extractString(lineItem.billableService || lineItem.item)}</StructuredListCell>
+                    <StructuredListCell>{lineItem.quantity}</StructuredListCell>
+                    <StructuredListCell>{convertToCurrency(lineItem.price, defaultCurrency)}</StructuredListCell>
+                    <StructuredListCell>{lineItem.paymentStatus}</StructuredListCell>
+                    <StructuredListCell>
+                      {convertToCurrency(lineItem.quantity * lineItem.price, defaultCurrency)}
+                    </StructuredListCell>
+                  </StructuredListRow>
+                );
+              })}
+            </StructuredListBody>
+          </StructuredListWrapper>
+          {!enforceBillPayment && (
+            <p className={styles.providerMessage}>
+              {t(
+                'providerMessage',
+                'By clicking Proceed to care, you acknowledge that you have advised the patient to settle the bill.',
+              )}
+            </p>
+          )}
+        </ModalBody>
+      )}
+      <ModalFooter>
+        <Button kind="secondary" onClick={() => navigate({ to: `\${openmrsSpaBase}/home` })}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button kind="danger" onClick={handleCloseModal}>
+          {closeButtonText}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+};
+
+export default PromptPaymentModal;

--- a/src/prompt-payment/prompt-payment.scss
+++ b/src/prompt-payment/prompt-payment.scss
@@ -1,0 +1,18 @@
+@use '@carbon/type';
+@use '@carbon/colors';
+
+.bodyShort02 {
+  margin-bottom: 0.5rem;
+  @include type.type-style('body-compact-02');
+}
+
+.modalTitle {
+  @include type.type-style('productive-heading-03');
+  padding: 0.5rem 0;
+}
+
+.providerMessage {
+  @include type.type-style('heading-01');
+  color: colors.$red-50;
+  margin-top: 1.5rem;
+}

--- a/src/routes.json
+++ b/src/routes.json
@@ -8,6 +8,12 @@
     {
       "component": "billableServicesHome",
       "route": "billable-services"
+    },
+    {
+      "component": "requirePaymentModal",
+      "routeRegex": "^patient\/.+\/chart",
+      "online": true,
+      "offline": false
     }
   ],
   "extensions": [


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable

- [ ] My work includes tests or is validated by existing tests.

## Summary

- This PR displays a patient bill alert for patients with pending bills.
- When the config for enforcingBillPayment is set to true, the patient alert will pop, but one won't be able to proceed with providing care/opening the patient chart until the bill is cleared.
- When the config is set to false, the patient alert will pop, but the user can decide whether to proceed to care with the pending bill or cancel.

## Screenshots

https://github.com/user-attachments/assets/e9984550-6618-483d-ac84-4d30f049329c

## Related Issue
https://metsprogramme.atlassian.net/browse/EP-63
